### PR TITLE
Set trailing commas to warning

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
     "no-plusplus": "off",
     "object-curly-newline": "off",
     "comma-dangle": [
-      "error",
+      "warn",
       "always-multiline",
     ],
     "func-names": "off",


### PR DESCRIPTION
## Summary
- relax comma-dangle lint rule

## Testing
- `yarn lint:js` *(fails: ESLint couldn't find an eslint.config.cjs file)*
- `npx eslint@8 resources/scripts`

------
https://chatgpt.com/codex/tasks/task_e_683f45ac246c832abf39dd3f13467059